### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Streaming is done through a [controller](app/controllers/streams_controller.rb) 
 * MySQL, Postgresql, or SQLite
 * Memcache
 * Ruby (currently 2.1.1)
+* Git (Over 1.7.2)
 
 #### Setup
 


### PR DESCRIPTION
Hey guys,

Thank you for building awesome tools! I've experienced following unexpected errors in the git_repository. valid_url[1] method due to `git version`. The git of version 1.7.1 doesn't support `-c` option[2]. That option can use over 1.7.2 version[3]. So I've updated a readme doc.

```
$ git --version
git version 1.7.1
$ git -c core.askpass=true ls-remote -h https://github.com/samson-test-org/example-project.git
Unknown option: -c
usage: git [--version] [--exec-path[=GIT_EXEC_PATH]] [--html-path]
           [-p|--paginate|--no-pager] [--no-replace-objects]
           [--bare] [--git-dir=GIT_DIR] [--work-tree=GIT_WORK_TREE]
           [--help] COMMAND [ARGS]
```

[1] https://github.com/zendesk/samson/blob/master/app/models/git_repository.rb#L91
[2] http://git-scm.com/docs/git/1.7.1
[3] http://git-scm.com/docs/git/1.7.2
